### PR TITLE
Fix for colors whose value is only 1 digit

### DIFF
--- a/js/jquery.productColorizer.js
+++ b/js/jquery.productColorizer.js
@@ -94,7 +94,7 @@
 			    var blue = parseInt(color[2]);
 			    
 			    var rgb = blue | (green << 8) | (red << 16);
-			    return rgb.toString(16);
+			    return (0x1000000 + rgb).toString(16).slice(1) // fix for colors whose values are 1 digit for IE <10
 			};
 			
 		});

--- a/js/jquery.productColorizer.js
+++ b/js/jquery.productColorizer.js
@@ -94,7 +94,7 @@
 			    var blue = parseInt(color[2]);
 			    
 			    var rgb = blue | (green << 8) | (red << 16);
-			    return (0x1000000 + rgb).toString(16).slice(1) // fix for colors whose values are 1 digit for IE <10
+			    return (0x1000000 + rgb).toString(16).slice(1) // fix for colors whose red value is 1 digit
 			};
 			
 		});


### PR DESCRIPTION
IE didn't show the colors on the swatch spans if the red component was <10